### PR TITLE
feat: use synckit instead of deasync

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,18 +29,17 @@
     "prepublishOnly": "npm run build",
     "watch": "npm run build -- --watch",
     "dev": "esno src/index.ts",
-    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "build": "tsup src/index.ts src/worker.ts --format cjs,esm --dts --external ./worker",
     "publish:ci": "npm publish --access public",
     "release": "npx bumpp --commit --push --tag && npm run publish:ci"
   },
   "dependencies": {
-    "deasync": "^0.1.21",
     "debug": "^4.3.2",
-    "shiki": "^0.9.3"
+    "shiki": "^0.9.3",
+    "synckit": "^0.6.0"
   },
   "devDependencies": {
     "@antfu/eslint-config-ts": "^0.6.4",
-    "@types/deasync": "^0.1.1",
     "@types/debug": "^4.1.5",
     "@types/markdown-it": "^12.0.1",
     "@types/node": "^15.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,27 +2,25 @@ lockfileVersion: 5.3
 
 specifiers:
   '@antfu/eslint-config-ts': ^0.6.4
-  '@types/deasync': ^0.1.1
   '@types/debug': ^4.1.5
   '@types/markdown-it': ^12.0.1
   '@types/node': ^15.0.1
-  deasync: ^0.1.21
   debug: ^4.3.2
   eslint: ^7.25.0
   esno: ^0.5.0
   markdown-it: ^12.0.6
   shiki: ^0.9.3
+  synckit: ^0.6.0
   tsup: ^4.10.1
   typescript: ^4.2.4
 
 dependencies:
-  deasync: 0.1.21
   debug: 4.3.2
   shiki: 0.9.3
+  synckit: 0.6.0
 
 devDependencies:
   '@antfu/eslint-config-ts': 0.6.4_eslint@7.25.0+typescript@4.2.4
-  '@types/deasync': 0.1.1
   '@types/debug': 4.1.5
   '@types/markdown-it': 12.0.1
   '@types/node': 15.0.1
@@ -190,10 +188,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.4
       fastq: 1.10.0
-    dev: true
-
-  /@types/deasync/0.1.1:
-    resolution: {integrity: sha512-/AsDEUsHjyzMX0UjPgysggxFO8r7//c4aS9aeQwHzgs5POBsqaBFWW9+KYFGUyx/VYT4HrT/+JzAGTEEL2d4OQ==}
     dev: true
 
   /@types/debug/4.1.5:
@@ -481,12 +475,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /bindings/1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-    dependencies:
-      file-uri-to-path: 1.0.0
-    dev: false
-
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -615,15 +603,6 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
-
-  /deasync/0.1.21:
-    resolution: {integrity: sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==}
-    engines: {node: '>=0.11.0'}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      node-addon-api: 1.7.2
-    dev: false
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -1135,10 +1114,6 @@ packages:
       flat-cache: 3.0.4
     dev: true
 
-  /file-uri-to-path/1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-    dev: false
-
   /fill-range/7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
@@ -1624,10 +1599,6 @@ packages:
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
     dev: true
-
-  /node-addon-api/1.7.2:
-    resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
-    dev: false
 
   /node-modules-regexp/1.0.0:
     resolution: {integrity: sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=}
@@ -2137,6 +2108,13 @@ packages:
       has-flag: 4.0.0
     dev: true
 
+  /synckit/0.6.0:
+    resolution: {integrity: sha512-AYuCJsMNa/3m1UKxfM9edZEjsdz0Hj7namBHs1RAMcMxEJIBNrq3pUI5EmwtGNWPxOvozuVQtixMnzcMSWJ0xg==}
+    engines: {node: '>=12.3'}
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+
   /table/6.0.7:
     resolution: {integrity: sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==}
     engines: {node: '>=10.0.0'}
@@ -2197,6 +2175,10 @@ packages:
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
+
+  /tslib/2.3.1:
+    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
+    dev: false
 
   /tsup/4.10.1_typescript@4.2.4:
     resolution: {integrity: sha512-QP4Hg48V/0Vosts5FK72CN3ERves0cXhVy5zKWKYxZO7mN/uuWOqUUF1cvAxqTKt17dpLaKFvlZ/OD7x1L2T/g==}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,25 @@
+import { getHighlighter, IThemeRegistration, ILanguageRegistration, Highlighter } from 'shiki'
+import { runAsWorker } from 'synckit'
+
+let h: Highlighter
+
+function handler(command: 'getHighlighter', options: {
+  themes: IThemeRegistration[]
+  langs: ILanguageRegistration[]
+}): void
+function handler(command: 'codeToHtml', options: {
+  code: string
+  lang: string
+  theme: string | undefined
+}): Promise<string>
+async function handler(command: 'getHighlighter' | 'codeToHtml', options: any) {
+  if (command === 'getHighlighter') {
+    h = await getHighlighter(options)
+  }
+  else if (command === 'codeToHtml') {
+    const { code, lang, theme } = options
+    return h.codeToHtml(code, lang, theme)
+  }
+}
+
+runAsWorker(handler)


### PR DESCRIPTION
Fix #2.

This pr intends to start a further discussion on #2.

Essentially, it is `deasync` [issue](https://github.com/abbr/deasync/issues/151) and there has been no more discussion for a few weeks. 


A workaround is to use [synckit](https://www.npmjs.com/package/synckit). It may be a big change and we should have some tests for this.
I feel sorry that I don't know how to write tests for markdown-it plugins. So I just test it with my personal projects on my local machine.