### PR TITLE
For browsers and Deno

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "shiki": "^0.10.1",
-    "synckit": "^0.7.0"
+    "unasync": "^0.1.4"
   },
   "devDependencies": {
     "@antfu/eslint-config-ts": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "shiki": "^0.10.1",
-    "unasync": "^0.1.4"
+    "unasync": "^0.3.0"
   },
   "devDependencies": {
     "@antfu/eslint-config-ts": "^0.21.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'module'
 import type { Highlighter, ILanguageRegistration, IShikiTheme, IThemeRegistration } from 'shiki'
 import type MarkdownIt from 'markdown-it'
-import { createSyncFn } from 'synckit'
+import { createSyncFn } from 'unasync'
 
 export interface DarkModeThemes {
   dark: IThemeRegistration

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,6 @@
 import type { Highlighter, ILanguageRegistration, IThemeRegistration } from 'shiki'
 import { getHighlighter } from 'shiki'
-import { runAsWorker } from 'synckit'
+import { runAsWorker } from 'unasync'
 
 let h: Highlighter
 


### PR DESCRIPTION
Hello, thank you for the great plugin.
`synckit` uses `worker_threads`. This is problematic to run on browsers.
To handle this issue, I have created the alternative `unasync`.
Please consider to merge my request. Cheers.