### PR TITLE
fix: avoid errors when code lang is not in presets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ const MarkdownItShiki: MarkdownIt.PluginWithOptions<Options> = (markdownit, opti
 
   const highlightCode = (code: string, lang: string, theme?: string): string => {
     if (_highlighter)
-      return _highlighter.codeToHtml(code, lang || 'text', theme)
+      return _highlighter.codeToHtml(code, { lang: lang || 'text', theme })
 
     return syncRun('codeToHtml', {
       code,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,7 +19,11 @@ async function handler(command: 'getHighlighter' | 'codeToHtml', options: any) {
   }
   else if (command === 'codeToHtml') {
     const { code, lang, theme } = options
-    return h.codeToHtml(code, lang, theme)
+    const loadedLanguages = h.getLoadedLanguages()
+    if (loadedLanguages.includes(lang))
+      return h.codeToHtml(code, { lang })
+    else
+      return h.codeToHtml(code, { lang: 'text', theme })
   }
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

写markdown文档的时候使用了一些不在shiki预设中的代码类型，预期应该是渲染为文本，让我意外的是我直接收到了一个报错，而且我的node进程也因为这个停掉了。

When I was writing the markdown doc, I used some code types that are not in the `shiki` preset. It is expected that they should be rendered as text. To my surprise, I directly received an error message, and my node process was terminated because of this.

### Linked Issues

None

### Additional context

None

<!-- e.g. is there anything you'd like reviewers to focus on? -->
