### PR TITLE
feat: highlight lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ dist
 
 # IDE
 .idea
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -64,3 +64,39 @@ html:not(.dark) .shiki-dark {
 }
 ```
 
+### Highlight lines
+
+```js
+md.use(Shiki, {
+  highlightLines: true
+})
+```
+
+Add these to your CSS
+
+```css
+code[v-pre] { 
+  display: flex;
+  flex-direction: column;
+}
+
+.shiki .highlighted {
+  background: #7f7f7f20;
+  display: block;
+  margin: 0 -1rem;
+  padding: 0 1rem;
+}
+```
+
+Then you can highlight lines in code block.
+
+~~~
+```js {1-2}
+const md = new MarkdownIt()
+md.use(Shiki)
+
+const res = md.render(/** ... */)
+console.log(res)
+```
+~~~
+

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,4 +1,4 @@
-import type { Highlighter, ILanguageRegistration, IThemeRegistration } from 'shiki'
+import type { Highlighter, HtmlRendererOptions, ILanguageRegistration, IThemeRegistration } from 'shiki'
 import { getHighlighter } from 'shiki'
 import { runAsWorker } from 'synckit'
 
@@ -12,18 +12,19 @@ function handler(command: 'codeToHtml', options: {
   code: string
   lang: string
   theme: string | undefined
+  lineOptions: HtmlRendererOptions['lineOptions']
 }): Promise<string>
 async function handler(command: 'getHighlighter' | 'codeToHtml', options: any) {
   if (command === 'getHighlighter') {
     h = await getHighlighter(options)
   }
   else if (command === 'codeToHtml') {
-    const { code, lang, theme } = options
+    const { code, lang, theme, lineOptions } = options
     const loadedLanguages = h.getLoadedLanguages()
     if (loadedLanguages.includes(lang))
-      return h.codeToHtml(code, { lang, theme })
+      return h.codeToHtml(code, { lang, theme, lineOptions })
     else
-      return h.codeToHtml(code, { lang: 'text', theme })
+      return h.codeToHtml(code, { lang: 'text', theme, lineOptions })
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -21,7 +21,7 @@ async function handler(command: 'getHighlighter' | 'codeToHtml', options: any) {
     const { code, lang, theme } = options
     const loadedLanguages = h.getLoadedLanguages()
     if (loadedLanguages.includes(lang))
-      return h.codeToHtml(code, { lang })
+      return h.codeToHtml(code, { lang, theme })
     else
       return h.codeToHtml(code, { lang: 'text', theme })
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add highlight lines to `markdown-it-shiki`, that is, you can set highlighted line like

~~~
```python {4-7}
def update(self, dt: float = 0, recurse: bool = True):
    if not self.has_updaters or self.updating_suspended:
        return self
    for updater in self.time_based_updaters:
        updater(self, dt)
    for updater in self.non_time_updaters:
        updater(self)
    # ...
```
~~~

<img width="660" alt="image" src="https://user-images.githubusercontent.com/55699713/204135543-0ab6af97-b66c-4c29-bb76-c361c905fd84.png">

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The syntax highlighting of vitepress is based on shiki, but the plugin `markdown-it-shiki` does not support it now. As a result, I tried to implement it here.

