### PR TITLE
fix: honor `highlightLines` when `theme` is a string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ const MarkdownItShiki: MarkdownIt.PluginWithOptions<Options> = (markdownit, opti
       return `<div class="shiki-container">${dark}${light}</div>`
     }
     else {
-      return highlightCode(code, lang || 'text')
+      return highlightCode(code, lang || 'text', null, lineOptions)
     }
   }
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When the `theme` option is provided as string (e.g. `theme: 'nord'`) instead of object (e.g. `theme: { dark: 'min-dark', light: 'min-light' }`) the `highlightLines` option gets ignored because `lineOptions` is not passed to `highlightCode`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
