### PR TITLE
fix: make output more consistent with markdown-it's defaults

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ const MarkdownItShiki: MarkdownIt.PluginWithOptions<Options> = (markdownit, opti
         lang || 'text',
         undefined,
         lineOptions,
-      )
+      ).replace('<code>', `<code class="language-${lang}">`)
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ const MarkdownItShiki: MarkdownIt.PluginWithOptions<Options> = (markdownit, opti
     })
   }
 
-  markdownit.options.highlight = (code, lang, attrs) => {
+  markdownit.options.highlight = (code, lang = 'text', attrs) => {
     let lineOptions
     if (highlightLines) {
       const match = RE.exec(attrs)
@@ -120,14 +120,14 @@ const MarkdownItShiki: MarkdownIt.PluginWithOptions<Options> = (markdownit, opti
     if (darkModeThemes) {
       const dark = highlightCode(code, lang, darkModeThemes.dark, lineOptions)
         .replace('<pre class="shiki"', '<pre class="shiki shiki-dark"')
-      const light = highlightCode(code, lang || 'text', darkModeThemes.light, lineOptions)
+      const light = highlightCode(code, lang, darkModeThemes.light, lineOptions)
         .replace('<pre class="shiki"', '<pre class="shiki shiki-light"')
-      return `<div class="shiki-container">${dark}${light}</div>`
+      return `<div class="shiki-container language-${lang}">${dark}${light}</div>`
     }
     else {
       return highlightCode(
         code,
-        lang || 'text',
+        lang,
         undefined,
         lineOptions,
       ).replace('<code>', `<code class="language-${lang}">`)


### PR DESCRIPTION
Hi there! First of all, nice package!! I hope it's ok that I am creating a PR without having created an issue first.

### Description

Markdown-it renders fenced code blocks like this by default (notice the `language-x` class on the `<code>` element):

```html
<pre>
<code class="language-bash">...</code>
</pre>
```

The `language-x` class is not being emitted by Shiki:

```html
<pre class="shiki github-dark-dimmed" style="background-color: #22272e" tabindex="0">
<code>...</code>
</pre>
```

This PR re-injects the language class into the code element:

```html
<pre class="shiki github-dark-dimmed" style="background-color: #22272e" tabindex="0">
<code class="language-bash">...</code>
</pre>
```
