### PR TITLE
feat: optimize output structure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,7 @@ const MarkdownItShiki: MarkdownIt.PluginWithOptions<Options> = (markdownit, opti
         .replace('<pre class="shiki ', '<pre class="shiki shiki-dark ')
       const light = highlightCode(code, lang, darkModeThemes.light, lineOptions)
         .replace('<pre class="shiki ', '<pre class="shiki shiki-light ')
+      // The leading <pre hidden> prevents markdown-it from wrapping the output.
       return `<pre hidden></pre><div class="shiki-container language-${lang}">${dark}${light}</div>`
     }
     else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ const MarkdownItShiki: MarkdownIt.PluginWithOptions<Options> = (markdownit, opti
         .replace('<pre class="shiki ', '<pre class="shiki shiki-dark ')
       const light = highlightCode(code, lang, darkModeThemes.light, lineOptions)
         .replace('<pre class="shiki ', '<pre class="shiki shiki-light ')
-      return `<div class="shiki-container language-${lang}">${dark}${light}</div>`
+      return `<pre hidden></pre><div class="shiki-container language-${lang}">${dark}${light}</div>`
     }
     else {
       return highlightCode(

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ const MarkdownItShiki: MarkdownIt.PluginWithOptions<Options> = (markdownit, opti
         .replace('<pre class="shiki ', '<pre class="shiki shiki-dark ')
       const light = highlightCode(code, lang, darkModeThemes.light, lineOptions)
         .replace('<pre class="shiki ', '<pre class="shiki shiki-light ')
-      // The leading <pre hidden> prevents markdown-it from wrapping the output.
+      // Prepend the result with <pre hidden> to skip markdown-it's internal wrapper
       return `<pre hidden></pre><div class="shiki-container language-${lang}">${dark}${light}</div>`
     }
     else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,9 +119,9 @@ const MarkdownItShiki: MarkdownIt.PluginWithOptions<Options> = (markdownit, opti
     }
     if (darkModeThemes) {
       const dark = highlightCode(code, lang, darkModeThemes.dark, lineOptions)
-        .replace('<pre class="shiki"', '<pre class="shiki shiki-dark"')
+        .replace('<pre class="shiki ', '<pre class="shiki shiki-dark ')
       const light = highlightCode(code, lang, darkModeThemes.light, lineOptions)
-        .replace('<pre class="shiki"', '<pre class="shiki shiki-light"')
+        .replace('<pre class="shiki ', '<pre class="shiki shiki-light ')
       return `<div class="shiki-container language-${lang}">${dark}${light}</div>`
     }
     else {


### PR DESCRIPTION
Fixes #17 

### Description

Two output optimizations:

- Makes sure injecting the classes `shiki-dark`/`shiki-light` is working as intended. The `replace()` was wrongly assuming a trailing quote `"` after the first class name `shiki` and hence not injecting the classes at all
- Prepend code blocks with light/dark theme with a `<pre hidden></pre>` as discussed in #17 

